### PR TITLE
Fixed a bug in delay() which appears for values below 1000

### DIFF
--- a/shiftpi.py
+++ b/shiftpi.py
@@ -98,7 +98,7 @@ def delay(millis):
     '''
     Used for creating a delay between commands
     '''
-    millis_to_seconds = millis/1000
+    millis_to_seconds = float(millis)/1000
     return sleep(millis_to_seconds)
 
 def _all_pins():


### PR DESCRIPTION
Division with integers wont work if the result will be a floating point value below 1.

1000 / 1000 = 1
900 / 1000 = 0
900.0 / 1000 = 0.9
